### PR TITLE
refactor: correct header includes

### DIFF
--- a/get_next_line/get_next_line.c
+++ b/get_next_line/get_next_line.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../includes/cub3d.h"
+#include "cub3d.h"
 
 char	*ft_free(char *buffer, char *buf)
 {

--- a/includes/cub3d.h
+++ b/includes/cub3d.h
@@ -15,7 +15,7 @@
 
 # include "colors.h"
 # include "libft.h"
-# include <../minilibx-linux/mlx.h>
+# include "mlx.h"
 # include <X11/keysym.h>
 # include <fcntl.h>
 # include <math.h>

--- a/src/libft/ft_calloc.c
+++ b/src/libft/ft_calloc.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../includes/libft.h"
+#include "libft.h"
 
 void	*ft_calloc(size_t num, size_t size)
 {

--- a/src/libft/ft_memset.c
+++ b/src/libft/ft_memset.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../includes/cub3d.h"
+#include "libft.h"
 
 void	*ft_memset(void *s, int c, size_t n)
 {

--- a/src/libft/ft_split.c
+++ b/src/libft/ft_split.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../includes/libft.h"
+#include "libft.h"
 
 int	count_words(const char *str, char c)
 {

--- a/src/parsing/free_game.c
+++ b/src/parsing/free_game.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../../includes/cub3d.h"
+#include "cub3d.h"
 
 void	free_given_file(t_data *game)
 {

--- a/src/parsing/parse_file.c
+++ b/src/parsing/parse_file.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../../includes/cub3d.h"
+#include "cub3d.h"
 
 void	validate_full_map(t_data *game)
 {

--- a/src/parsing/parse_file1.c
+++ b/src/parsing/parse_file1.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../../includes/cub3d.h"
+#include "cub3d.h"
 
 int	is_direction(char *line)
 {

--- a/src/parsing/parse_file2.c
+++ b/src/parsing/parse_file2.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../../includes/cub3d.h"
+#include "cub3d.h"
 
 int	count_commas(char *line)
 {

--- a/src/parsing/parse_file3.c
+++ b/src/parsing/parse_file3.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../../includes/cub3d.h"
+#include "cub3d.h"
 
 void	parse_rgb(t_data *game, char **splitted)
 {

--- a/src/parsing/parse_file4.c
+++ b/src/parsing/parse_file4.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../../includes/cub3d.h"
+#include "cub3d.h"
 
 int	error_exit(t_data *game, char *str, char *error_message)
 {

--- a/src/parsing/utils.c
+++ b/src/parsing/utils.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../../includes/cub3d.h"
+#include "cub3d.h"
 
 void	free_matrix(char **matrix)
 {

--- a/src/parsing/validate_map.c
+++ b/src/parsing/validate_map.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../../includes/cub3d.h"
+#include "cub3d.h"
 
 int	is_player_char(char c)
 {

--- a/src/parsing/validate_map1.c
+++ b/src/parsing/validate_map1.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../../includes/cub3d.h"
+#include "cub3d.h"
 
 int	validate_map_walls(t_data *game)
 {

--- a/src/parsing/validate_map2.c
+++ b/src/parsing/validate_map2.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../../includes/cub3d.h"
+#include "cub3d.h"
 
 int	validate_map(t_data *game)
 {

--- a/src/render/calculations.c
+++ b/src/render/calculations.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../includes/cub3d.h"
+#include "cub3d.h"
 
 void	calculate_wall_height(t_ray *r, t_data *d)
 {

--- a/src/render/handle_keys.c
+++ b/src/render/handle_keys.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../includes/cub3d.h"
+#include "cub3d.h"
 
 void	update_controls(t_data *data)
 {

--- a/src/render/handle_movements.c
+++ b/src/render/handle_movements.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../includes/cub3d.h"
+#include "cub3d.h"
 
 void	move_forward(t_data *data)
 {

--- a/src/render/handle_rotations.c
+++ b/src/render/handle_rotations.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../includes/cub3d.h"
+#include "cub3d.h"
 
 void	rotate_left(t_data *data)
 {

--- a/src/render/player.c
+++ b/src/render/player.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../includes/cub3d.h"
+#include "cub3d.h"
 
 void	init_pos_ew(char dir, t_data **data)
 {

--- a/src/render/rendering.c
+++ b/src/render/rendering.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../includes/cub3d.h"
+#include "cub3d.h"
 
 int	rgb_to_int(t_color color)
 {

--- a/src/render/textures.c
+++ b/src/render/textures.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../includes/cub3d.h"
+#include "cub3d.h"
 
 static int	get_tex_index(t_ray *ray)
 {

--- a/src/render/window.c
+++ b/src/render/window.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../includes/cub3d.h"
+#include "cub3d.h"
 
 int	close_window(t_data *data)
 {


### PR DESCRIPTION
## Summary
- Standardize project headers by relying on include search paths instead of brittle relative references.
- Fix libft and core includes, including using `mlx.h` via include directory.

## Testing
- `make` *(fails: No rule to make target 'minilibx-linux/libmlx.a' — MiniLibX is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689527eb15d083299e8c3eb7bfb4fe2a